### PR TITLE
Change the front color when cursor is on the character to make it visible.

### DIFF
--- a/02. Argonaut.reg
+++ b/02. Argonaut.reg
@@ -5,7 +5,7 @@ Windows Registry Editor Version 5.00
 "Colour1"="158,156,154"
 "Colour2"="14,16,25"
 "Colour3"="14,16,25"
-"Colour4"="255,0,24"
+"Colour4"="255,255,255"
 "Colour5"="255,0,24"
 "Colour6"="35,35,35"
 "Colour7"="68,68,68"

--- a/14. Highway.reg
+++ b/14. Highway.reg
@@ -5,7 +5,7 @@ Windows Registry Editor Version 5.00
 "Colour1"="255,248,216"
 "Colour2"="34,34,37"
 "Colour3"="34,34,37"
-"Colour4"="224,217,185"
+"Colour4"="34,34,37"
 "Colour5"="237,237,237"
 "Colour6"="0,0,0"
 "Colour7"="93,80,74"

--- a/23. Liquid Carbon.reg
+++ b/23. Liquid Carbon.reg
@@ -5,7 +5,7 @@ Windows Registry Editor Version 5.00
 "Colour1"="255,255,255"
 "Colour2"="48,48,48"
 "Colour3"="48,48,48"
-"Colour4"="255,255,255"
+"Colour4"="48,48,48"
 "Colour5"="175,194,194"
 "Colour6"="0,0,0"
 "Colour7"="0,0,0"


### PR DESCRIPTION
Original color setting for the cursor text is not easy to be recognized under cursor color.